### PR TITLE
PWM frequency correction

### DIFF
--- a/hotwire/Hotwire.h
+++ b/hotwire/Hotwire.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 
-#define HOTWIRE_PWM_MAX 0xFFFF
+#define HOTWIRE_PWM_MAX 0xFF
 
 // EFFECTS: initializes the device for PWM on the hotwire output
 void Hotwire_init();


### PR DESCRIPTION
Setting `HOTWIRE_PWM_MAX` to 0xFFFF (65536) results in a 244Hz PWM frequency (see equation on page 134 of datasheet, 16.9.3). Hotwire's been running at the wrong frequency this whole time. No idea how I didn't catch that earlier. 0xFF (256) is the correct value for 62.5kHz PWM.